### PR TITLE
fix failure on first execution

### DIFF
--- a/goods.bat
+++ b/goods.bat
@@ -1,11 +1,12 @@
 @echo off
+setlocal enabledelayedexpansion
 ::腳本
 if "%~1"=="" (
     echo Open test.txt
     for /f %%a in (test.txt) do (
       set varA=%%a
-      set www=%varA:~12,4%
-      if "%www%"=="yout" (
+      set www=!varA:~12,4!
+      if "!www!"=="yout" (
         yt-dlp ^
         --embed-metadata ^
         --embed-thumbnail ^
@@ -16,7 +17,7 @@ if "%~1"=="" (
         --output "%%(channel)s/[%%(upload_date)s]%%(title)s.%%(ext)s" ^
         --output "thumbnail:%%(channel)s/[%%(upload_date)s]%%(title)s.%%(ext)s" 
       ) ^
-      else if "%www%"=="nico" (
+      else if "!www!"=="nico" (
         yt-dlp ^
         --cookies www.nicovideo.jp_cookies.txt ^
         --embed-metadata ^
@@ -30,9 +31,9 @@ if "%~1"=="" (
     echo http
     set varA=%~1
     echo %varA%
-    set www=%varA:~8,11%
+    set www=!varA:~8,11!
     echo %www%
-    if "%www%"=="www.youtube" (
+    if "!www!"=="www.youtube" (
         echo youtube
         yt-dlp ^
         --embed-metadata ^
@@ -43,7 +44,7 @@ if "%~1"=="" (
         %~1 ^
         --output "%%(channel)s/[%%(upload_date)s]%%(title)s.%%(ext)s" ^
         --output "thumbnail:%%(channel)s/[%%(upload_date)s]%%(title)s.%%(ext)s" 
-    ) else if "%www%"=="nicochannel" (
+    ) else if "!www!"=="nicochannel" (
         echo nico
         yt-dlp ^
         --cookies nicochannel.jp_cookies.txt ^


### PR DESCRIPTION
Fix https://github.com/haha4ni/yt-dlp-script/issues/2

### Root cause
delayed variable expansion was not enabled, causing variables within conditional statements to not be properly expanded at runtime.

### Solution
Add "enabledelayedexpansion" token and modify the corresponding symbols (%% => !!)